### PR TITLE
Fix settings icons not being centered and plugin settings button not having propper styling

### DIFF
--- a/assets/src/tabs/Plugins.tsx
+++ b/assets/src/tabs/Plugins.tsx
@@ -27,8 +27,8 @@ const EditPlugin: React.FC<EditPluginProps> = ({ plugin }) => {
 	}
 
 	return (
-		<DialogButton className="_3epr8QYWw_FqFgMx38YEEm" style={{marginTop: 0, marginLeft: 0, marginRight: 15}}>
-			<IconsModule.Settings />
+		<DialogButton className="_3epr8QYWw_FqFgMx38YEEm millenniumIconButton">
+			<IconsModule.Settings height="16" />
 		</DialogButton>
 	)
 }
@@ -80,6 +80,18 @@ const PluginViewModal: React.FC = () => {
 
 	return (
 		<>
+		<style>
+		{`
+			button.millenniumIconButton {
+				padding: 9px 10px !important; 
+				margin: 0 !important; 
+				margin-right: 10px !important;
+				display: flex;
+				width: auto;
+			}
+		`}
+		</style>
+
 		<DialogHeader>{locale.settingsPanelPlugins}</DialogHeader>
 		<DialogBody className={classMap.SettingsDialogBodyFade}>
 			{plugins.map((plugin: PluginComponent, index: number) => (

--- a/assets/src/tabs/Themes.tsx
+++ b/assets/src/tabs/Themes.tsx
@@ -86,7 +86,6 @@ const RenderEditTheme: React.FC<EditThemeProps> = ({ active }) => {
     return (
         <DialogButton 
             onClick={() => ThemeSettings(active)}
-            style={{margin: "0", padding: "0px 10px", marginRight: "10px"}} 
             className="_3epr8QYWw_FqFgMx38YEEm millenniumIconButton" 
         >
             <IconsModule.Settings height="16" />
@@ -206,7 +205,18 @@ const ThemeViewModal: React.FC = () => {
 
     return (
         <>
-            <style>{`.DialogDropDown._DialogInputContainer.Panel.Focusable { min-width: max-content !important; }`}</style>
+            <style>
+            {`
+                .DialogDropDown._DialogInputContainer.Panel.Focusable { min-width: max-content !important; }
+                button.millenniumIconButton {
+                    padding: 9px 10px !important; 
+                    margin: 0 !important; 
+                    margin-right: 10px !important;
+                    display: flex;
+                    width: auto;
+                }
+            `}
+            </style>
 
             <DialogHeader>{locale.settingsPanelThemes}</DialogHeader>
             <DialogBody className={classMap.SettingsDialogBodyFade}>
@@ -227,7 +237,6 @@ const ThemeViewModal: React.FC = () => {
                     {!pluginSelf.isDefaultTheme && (
                         <DialogButton
                             onClick={() => SetupAboutRenderer(active)}
-                            style={{ margin: "0", padding: "0px 10px", marginRight: "10px" }}
                             className="_3epr8QYWw_FqFgMx38YEEm millenniumIconButton"
                         >
                             <IconsModule.Information height="16" />
@@ -236,7 +245,6 @@ const ThemeViewModal: React.FC = () => {
         
                     <DialogButton
                         onClick={OpenThemesFolder}
-                        style={{ margin: "0", padding: "0px 10px", marginRight: "10px" }}
                         className="_3epr8QYWw_FqFgMx38YEEm millenniumIconButton"
                     >
                         <CustomIcons.Folder />


### PR DESCRIPTION
Just a simple fix for the settings icons not being centered
  
Before:
![before themes](https://github.com/user-attachments/assets/d0d5c11c-f4cd-4a85-b5e0-8cd813615f06)
After:
![after themes](https://github.com/user-attachments/assets/01d1c914-a114-455f-b15f-1d801cf3ab80)

Before:
![before plugins](https://github.com/user-attachments/assets/0f45f5b3-ab6d-4e09-8c0d-1d0436481baf)
After:
![after plugins](https://github.com/user-attachments/assets/f749ed3e-df55-4769-964d-4c0d2cbb7f63)


