### PR TITLE
Install Millenium library in default installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,3 +214,5 @@ elseif(UNIX)
     endif()
   endif()
 endif()
+
+install(TARGETS Millennium DESTINATION lib)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -25,3 +25,5 @@ add_compile_definitions(MILLENNIUM_VERSION="${MILLENNIUM_VERSION}")
 
 set_target_properties(cli PROPERTIES OUTPUT_NAME "millennium")
 set_target_properties(cli PROPERTIES PREFIX "")
+
+install(TARGETS cli DESTINATION bin)


### PR DESCRIPTION
In one configuration (when we use bundled python package for Linux system) CMake doesn't rely on CMAKE_RUNTIME_OUTPUT_DIRECTORY to install libraries. Therefore, add installation step to copy that library.