### PR TITLE
fix: Remove leading "v" in pkgver

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Update Package Version
         run: |
-            sed -i "s/pkgver=.*/pkgver=$(sed -n '2p' ./version | tr -d '\n')/" ./pkgbuild/PKGBUILD
+            sed -i "s/pkgver=.*/pkgver=$(sed -n '2p' ./version | tr -d 'v\n')/" ./pkgbuild/PKGBUILD
 
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@master

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,4 +1,4 @@
-pkgver=v2.17.2
+pkgver=2.18.0
 pkgname=millennium
 pkgrel=1
 pkgdesc="Millennium is an open-source low-code modding framework to create, manage and use themes/plugins for the desktop Steam Client without any low-level internal interaction or overhead."


### PR DESCRIPTION
Remove leading "v" in pkgver since other packages don't contain it.
e.g.: `v2.18.0` → `2.18.0`