### PR TITLE
Fix missing comma in Spanish.json

### DIFF
--- a/assets/src/locales/locales/spanish.json
+++ b/assets/src/locales/locales/spanish.json
@@ -36,7 +36,7 @@
     "uninstall": "Desinstalar",
     "optionSaveChanges": "Guardar Cambios",
     "optionReloadNow": "Reiniciar Ahora",
-    "optionReloadLater": "Reiniciar Después"
+    "optionReloadLater": "Reiniciar Después",
     "optionReloadRequired": "Se requiere reiniciar",
     "optionPluginNeedsReload": "Para activar o desactivar los complementos seleccionados, se requiere reiniciar. ¿Estás seguro que quieres continuar?",
     "updatePanelUpdateNotifications": "Notificaciones",


### PR DESCRIPTION
Fixed Spanish.json missing a comma in Line 40 making it not compile on ArchLinux due to a JSON parsing error.